### PR TITLE
Fix directory path to install fairseq from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains the code for BERT-fused NMT, which is introduced in the
 To install fairseq from source and develop locally:
 ```
 git clone https://github.com/bert-nmt/bert-nmt
-cd bertnmt
+cd bert-nmt
 pip install --editable .
 ```
 


### PR DESCRIPTION
When cloning the repo to local machines, the directory name is `bert-nmt`, not `bertnmt`.